### PR TITLE
Add simple Socket.IO Pong demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,20 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Real-time Pong with Socket.IO
+
+This repo contains a simple multiplayer Pong game. Run the Socket.IO server with:
+
+```bash
+node server.js
+```
+
+Open `http://localhost:3001` in two browser windows to play.
+
+### Deploying to Render
+
+1. Push this repository to GitHub.
+2. Create a **Web Service** on [Render](https://render.com/).
+3. Set the build command to `npm install` and the start command to `node server.js`.
+4. The `PORT` environment variable is provided automatically by Render.

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "pong": "node server.js"
   },
   "dependencies": {
     "next": "15.3.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "express": "^4.19.2",
+    "socket.io": "^4.7.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/public/pong/index.html
+++ b/public/pong/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>Pong Multiplayer</title>
+  <style>
+    body { display:flex; justify-content:center; align-items:center; height:100vh; background:#222; color:#fff; margin:0; }
+    canvas { background:#000; }
+  </style>
+</head>
+<body>
+  <canvas id="game" width="600" height="400"></canvas>
+  <script src="/socket.io/socket.io.js"></script>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/public/pong/main.js
+++ b/public/pong/main.js
@@ -1,0 +1,48 @@
+const socket = io();
+let role = null;
+const canvas = document.getElementById('game');
+const ctx = canvas.getContext('2d');
+
+const paddleHeight = 80;
+const paddleWidth = 10;
+const paddleSpeed = 5;
+
+let leftY = canvas.height / 2 - paddleHeight / 2;
+let rightY = canvas.height / 2 - paddleHeight / 2;
+
+socket.on('role', r => { role = r; });
+
+socket.on('paddleMove', data => {
+  if (data.role === 'player1') leftY = data.y;
+  if (data.role === 'player2') rightY = data.y;
+});
+
+document.addEventListener('keydown', e => {
+  if (role === 'spectator') return;
+  if (e.key === 'ArrowUp') move(-paddleSpeed);
+  if (e.key === 'ArrowDown') move(paddleSpeed);
+});
+
+function move(delta) {
+  if (role === 'player1') {
+    leftY = Math.max(0, Math.min(canvas.height - paddleHeight, leftY + delta));
+    socket.emit('paddleMove', { y: leftY });
+  }
+  if (role === 'player2') {
+    rightY = Math.max(0, Math.min(canvas.height - paddleHeight, rightY + delta));
+    socket.emit('paddleMove', { y: rightY });
+  }
+}
+
+function draw() {
+  ctx.fillStyle = 'black';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  ctx.fillStyle = 'white';
+  ctx.fillRect(10, leftY, paddleWidth, paddleHeight);
+  ctx.fillRect(canvas.width - 20, rightY, paddleWidth, paddleHeight);
+
+  requestAnimationFrame(draw);
+}
+
+draw();

--- a/server.js
+++ b/server.js
@@ -1,0 +1,42 @@
+// Simple Socket.IO server for a two-player Pong game.
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
+
+const PORT = process.env.PORT || 3001;
+
+app.use(express.static('public/pong'));
+
+const players = {};
+
+io.on('connection', socket => {
+  let role = 'spectator';
+  if (!players.player1) {
+    players.player1 = socket.id;
+    role = 'player1';
+  } else if (!players.player2) {
+    players.player2 = socket.id;
+    role = 'player2';
+  }
+
+  socket.emit('role', role);
+  console.log(`Client ${socket.id} connected as ${role}`);
+
+  socket.on('paddleMove', data => {
+    socket.broadcast.emit('paddleMove', { role, y: data.y });
+  });
+
+  socket.on('disconnect', () => {
+    if (players.player1 === socket.id) delete players.player1;
+    if (players.player2 === socket.id) delete players.player2;
+    console.log(`Client ${socket.id} disconnected`);
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`Server listening on ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add express and socket.io dependencies
- implement `server.js` Socket.IO backend
- include HTML/JS game under `public/pong`
- document how to run and deploy the Pong demo
- provide npm script `pong`

## Testing
- `node server.js` *(fails: Cannot find module 'express')*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eef6565388333b97ef56a00e9ec4c